### PR TITLE
python36: update to 3.6.12

### DIFF
--- a/python36/PKGBUILD
+++ b/python36/PKGBUILD
@@ -6,7 +6,7 @@
 
 _py_ver=36
 pkgname=python$_py_ver
-pkgver=3.6.11
+pkgver=3.6.12
 pkgrel=1
 _pybasever=${pkgver%.*}
 pkgdesc='Next generation of the python high-level scripting language'
@@ -24,7 +24,7 @@ optdepends=('python-setuptools'
 provides=('python3')
 replaces=('python3')
 source=("https://www.python.org/ftp/python/${pkgver%rc*}/Python-$pkgver.tar.xz"{,.asc})
-sha512sums=('c76969a6602e095641ba5fd0999a47cf0187eb26559ba9a6e80fe401b8928f6cd9eabd963f615f7c667e48f56603f2508d2b5692c83ea8da1e21292131fb11d6'
+sha512sums=('1462801f3f6626a853097d34ccdca9838c4c5bd81ecc3abc751003f5f2f8d36eecdaa4130ef4218de351c5586093c11669639a34492668fbc5a2a4a241f4a070'
             'SKIP')
 validpgpkeys=('0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D')  # Ned Deily (Python release signing key) <nad@python.org>
 


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@archlinux.org>