### PR TITLE
github: enable workflow_dispatch, update versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: build
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -26,7 +27,7 @@ jobs:
         run: echo "::set-output name=date::$(date +%F)"
 
       - name: Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: /var/cache/pacman/pkg
           key: arch-pkgs-${{ steps.date.outputs.date }}
@@ -36,7 +37,7 @@ jobs:
         run: pacman -Syu --noconfirm --noprogressbar --needed base-devel devtools btrfs-progs dbus sudo git
 
       - name: Checkout main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: main
 


### PR DESCRIPTION
Updates actions/cache and actions/checkout to latest, to keep up to date.

[workflow_dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) event allows you to run the workflow whenever you want to, by simply pressing the Run workflow button in Actions page. Just a suggestion that won't affect the normal use of push/pull_request events.